### PR TITLE
Simple IPv4-to-integer sandbox program

### DIFF
--- a/sandbox/inet_pton.py
+++ b/sandbox/inet_pton.py
@@ -21,9 +21,27 @@ def display_pton(ip="8.8.8.8"):
     binstr, int32 = inet_pton(ip)
     print("{:<15} -> {} ({})".format(ip, binstr, int32))
 
+def inet_pton_bitwise(ip):
+    '''
+    Bitwise implementation of converter from IPv4 IP to 32-bit integer in 
+    big-endian Network Byte Order 
+    '''
+
+    num = 0
+    for chunk in ip.split('.'):
+        num <<= 8
+        num |= int(chunk)
+
+    print("{:<15} -> {} ({})".format(ip, bin(num), num))
+
+    return num
 
 if __name__ == '__main__':
 
     display_pton("8.8.8.8")
     display_pton("31.13.70.36")
     display_pton("172.217.14.78")
+
+    inet_pton2("8.8.8.8")
+    inet_pton2("31.13.70.36")
+    inet_pton2("172.217.14.78")

--- a/sandbox/inet_pton.py
+++ b/sandbox/inet_pton.py
@@ -42,6 +42,6 @@ if __name__ == '__main__':
     display_pton("31.13.70.36")
     display_pton("172.217.14.78")
 
-    inet_pton2("8.8.8.8")
-    inet_pton2("31.13.70.36")
-    inet_pton2("172.217.14.78")
+    inet_pton_bitwise("8.8.8.8")
+    inet_pton_bitwise("31.13.70.36")
+    inet_pton_bitwise("172.217.14.78")

--- a/sandbox/ipv4_to_i.c
+++ b/sandbox/ipv4_to_i.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+int main()
+{
+    char c, ipv4[16];
+    int i;
+
+    i = 0;
+    while ((c = getchar()) != EOF)
+    {
+        if (c == '\n') {
+            ipv4[i] = '\0';
+            printf("You entered: %s\n", ipv4);
+            for (; i>0; --i)
+                ipv4[i] = '\0';
+        } else if (i < 15) {
+            ipv4[i++] = c;
+        }
+    }
+}

--- a/sandbox/ipv4_to_i.c
+++ b/sandbox/ipv4_to_i.c
@@ -1,20 +1,47 @@
 #include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 int main()
 {
-    char c, ipv4[16];
+    char c, chunk[4];
     int i;
+    uint32_t addr;
 
     i = 0;
+    addr = 0;
+
     while ((c = getchar()) != EOF)
     {
-        if (c == '\n') {
-            ipv4[i] = '\0';
-            printf("You entered: %s\n", ipv4);
-            for (; i>0; --i)
-                ipv4[i] = '\0';
-        } else if (i < 15) {
-            ipv4[i++] = c;
+
+        /* convert chunk to int if we reach a `.` or `\n` */
+        if (c == '.' || c == '\n') {
+            chunk[i] = '\0';
+            //printf("Cur chunk %s -> %d\n", chunk, atoi(chunk));
+
+            addr <<= 8;
+            addr |= atoi(chunk);
+            
+            // reset chunk
+            for (; i>0; --i) { chunk[i] = '\0'; }
+
+            // output addr and reset on newline
+            if (c == '\n') {
+                printf("%u\n", addr);
+                addr = 0;
+            }
+
+        /* else append char to chunk if numeric */
+        } else if (i < 3 && c >= '0' && c <= '9'){
+            chunk[i++] = c;
         }
     }
+    
+    return 0;
 }
+
+/*
+ * to do:
+ * - handle cases where atoi(chunk) > 255
+ * - handle cases where not expected number of chunks (might be better to read in full ipv4 address for this)
+ */

--- a/sandbox/ipv4_to_i.c
+++ b/sandbox/ipv4_to_i.c
@@ -5,29 +5,45 @@
 int main()
 {
     char c, chunk[4];
-    int i;
+    int i, chunk_as_i, chunks_count;
     uint32_t addr;
 
     i = 0;
     addr = 0;
+    chunks_count = 0;
 
     while ((c = getchar()) != EOF)
     {
 
         /* convert chunk to int if we reach a `.` or `\n` */
         if (c == '.' || c == '\n') {
-            chunk[i] = '\0';
-            //printf("Cur chunk %s -> %d\n", chunk, atoi(chunk));
-
-            addr <<= 8;
-            addr |= atoi(chunk);
+            chunk[i] = '\0';            // append null to chunk
+            addr <<= 8;                 // shift addr 8 bits left
+            chunk_as_i = atoi(chunk);   // convert current chunk to int
+            if (chunk_as_i > 255) {     // exit on invalid chunk
+                printf("Invalid IPv4 address component: %s\n", chunk);
+                return 1;
+            }
+            addr |= atoi(chunk);        // add chunk to addr
             
             // reset chunk
             for (; i>0; --i) { chunk[i] = '\0'; }
 
+            // inc chunks_count
+            chunks_count++;
+
             // output addr and reset on newline
             if (c == '\n') {
-                printf("%u\n", addr);
+                if (chunks_count == 4) {
+                    printf("%u\n", addr);
+                } else {
+                    printf("Unexpected IPv4 address format ");
+                    for (int j=1; j<chunks_count; ++j)
+                        printf("x.");
+                    printf("x\n");
+                    return 1;
+                }
+                chunks_count = 0;
                 addr = 0;
             }
 
@@ -39,9 +55,3 @@ int main()
     
     return 0;
 }
-
-/*
- * to do:
- * - handle cases where atoi(chunk) > 255
- * - handle cases where not expected number of chunks (might be better to read in full ipv4 address for this)
- */


### PR DESCRIPTION
ipv4_to_i.c is a program that converts a valid IPv4 address (x.x.x.x) into its 32-bit integer equivalent. As preparation, I also updated inet_pton.py to include a Python implementation of this conversion using bitwise operations.