### PR TITLE
Update .gitignore to exclude tapes/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # Ignore tapes/ (for screen recording)
 tapes/
+
+# adding a meangingless comment to test whether I can merge after approval

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Unignore all dirs
 !*/
+
+# Ignore tapes/ (for screen recording)
+tapes/


### PR DESCRIPTION
This pull request updates the .gitignore file to exclude the tapes/ directory from version control. I'm using the tapes/ directory to store .tapes files (used by [VHS](https://github.com/charmbracelet/vhs) for recording the terminal), along with the .gifs they generate.