### PR TITLE
Revise NewDNSQuery() to return *DNSQuery

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -47,7 +47,7 @@ DNSQuestion* NewDNSQuestion(char *encoded_name, uint16_t type, uint16_t class)
 //              domain_name (char*): domain name to resolve in presentation format
 //              record_type: e.g., TYPE_A = 1
 // Returns:    Pointer to malloc'ed DNSQuery
-DNSQuery NewDNSQuery(char *domain_name, uint16_t record_type) // Change to DNSQuery*
+DNSQuery *NewDNSQuery(char *domain_name, uint16_t record_type) 
 {
     // create header
     int        id = 0; // TODO general random ID to pass to NewHeader()
@@ -60,13 +60,14 @@ DNSQuery NewDNSQuery(char *domain_name, uint16_t record_type) // Change to DNSQu
     DNSQuestion* question = NewDNSQuestion(encoded_domain, record_type, CLASS_IN);
 
     // build query
-    size_t query_len    = sizeof(*header) + 4 + strlen(question->encoded_name) + 1;
-    char*  query_string = malloc(query_len);
-    DNSQuery  full_query   = { .len = query_len, .s = query_string };
-    header_to_bytes(header, full_query.s);
-    question_to_bytes(question, full_query.s + sizeof(*header));
+    DNSQuery* query = calloc(1, sizeof(DNSQuery));
+    query->len = sizeof(*header) + 4 + strlen(question->encoded_name) + 1;
+    query->s = malloc(query->len);
+    
+    header_to_bytes(header, query->s);
+    question_to_bytes(question, query->s + sizeof(*header));
 
-    return full_query;
+    return query;
 }
 
 DNSPacket *NewDNSPacket(char *response_bytes) {

--- a/dns.h
+++ b/dns.h
@@ -57,7 +57,7 @@ typedef struct DNSPacket
 
 DNSHeader*   NewDNSHeader(uint16_t id, uint16_t flags, uint16_t num_questions);
 DNSQuestion* NewDNSQuestion(char *encoded_name, uint16_t type, uint16_t class);
-DNSQuery     NewDNSQuery(char *domain_name, uint16_t record_type); // change to DNSQuery*
+DNSQuery*    NewDNSQuery(char *domain_name, uint16_t record_type);
 DNSPacket*   NewDNSPacket(char *response_bytes);
 
 void         display_DNSHeader(DNSHeader *header);

--- a/main.c
+++ b/main.c
@@ -34,17 +34,17 @@ int main(int argc, char **argv)
     sockfd = socket(PF_INET, SOCK_DGRAM, 0);
 
     // create query
-    DNSQuery query = NewDNSQuery(argv[1], TYPE_A);
+    DNSQuery *query = NewDNSQuery(argv[1], TYPE_A);
     
     // send query
-    ssize_t bytes_sent = sendto(sockfd, query.s, query.len, 0, (struct sockaddr *)&dest, sizeof dest);
+    ssize_t bytes_sent = sendto(sockfd, query->s, query->len, 0, (struct sockaddr *)&dest, sizeof dest);
     if (bytes_sent == -1)
         perror("sendto");
 
     // print query bytes
     printf("%ld bytes sent: \n", bytes_sent);
-    for (int i=0; i<query.len; ++i) {
-        printf("%x/", (char)query.s[i]);
+    for (int i=0; i<query->len; ++i) {
+        printf("%x/", (char)query->s[i]);
     }
     printf("\n\n");
 


### PR DESCRIPTION
- Revise `NewDNSQuery()` constructor to return `*DNSQuery` rather than `DNSQuery`, thus rendered more consistent with other constructor functions, which similarly heap-allocate structs and return pointers.
- Cleanup code and remove unnecessary variables