### PR TITLE
Implement destroy functions for all DNS structs

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -519,6 +519,73 @@ void display_DNSPacket(DNSPacket *packet)
     display_DNSHeader(packet->header);
     display_DNSQuestion(packet->questions);
     display_DNSRecord(packet->answers);
-    //display_DNSRecord(packet->additionals);
-    //display_DNSRecord(packet->authorities);
+    display_DNSRecord(packet->additionals);
+    display_DNSRecord(packet->authorities);
+}
+
+int destroy_DNSPacket(DNSPacket **packet) {
+    destroy_DNSHeader(&((*packet)->header));
+    destroy_DNSQuestion(&((*packet)->questions));
+    destroy_DNSRecord(&((*packet)->answers));
+    destroy_DNSRecord(&((*packet)->authorities));
+    destroy_DNSRecord(&((*packet)->authorities));
+    free(*packet);
+    (*packet) = NULL;
+    return 0;
+}
+
+int destroy_DNSHeader(DNSHeader **header) {
+    free(*header);
+    (*header) = NULL;
+    return 0;
+}
+
+int destroy_DNSQuestion(DNSQuestion **question) {
+    // Am I correctly destroying the *next link? Is there a mem leak here?
+    DNSQuestion **cur  = question;
+    DNSQuestion **next = &((*cur)->next);
+
+    while ((*cur) != NULL) {
+        next = &((*cur)->next); // hold reference to next, since current node will be freed
+
+        free((*cur)->name);
+        (*cur)->name = NULL;
+
+        (*cur)->next = NULL;
+        
+        free(*cur);
+        *cur = NULL;
+
+        cur = next;
+    }
+
+    return 0;
+}
+
+int destroy_DNSRecord(DNSRecord **record) {
+    // Am I correctly destroying the *next link? Is there a mem leak here?
+    DNSRecord **cur  = record;
+    DNSRecord **next = &((*cur)->next);
+
+    while (*cur != NULL) {
+        next = &((*cur)->next); // hold reference to next, since current node will be freed
+
+        free((*cur)->name);
+        (*cur)->name = NULL;
+
+        free((*cur)->data_bytes);
+        (*cur)->data_bytes = NULL;
+
+        free((*cur)->data);
+        (*cur)->data = NULL;
+
+        (*cur)->next = NULL;
+
+        free(*cur);
+        *cur = NULL;
+
+        cur = next;
+    }
+
+    return 0;
 }

--- a/dns.h
+++ b/dns.h
@@ -12,8 +12,8 @@
 // typedef struct DNSQuery DNSQuery;
 typedef struct DNSQuery
 {
-	size_t len;
-	char*  s;
+	size_t  len;
+	char   *s;
 } DNSQuery;
 
 typedef struct DNSHeader
@@ -30,7 +30,7 @@ typedef struct DNSHeader
 typedef struct DNSQuestion
 {
     // stored in network byte order
-    char                *name;
+    char               *name;
     u_int16_t           type;       // set to TYPE_A=1 (A Record)
     u_int16_t           class;      // set to CLASS_IN=1 (for internet)
     struct DNSQuestion *next;       // linked list next pointer
@@ -46,17 +46,17 @@ typedef struct DNSRecord
     uint16_t          bytes_len;    // length of data bytes NOTE: net-byte-order!
     size_t            data_len;    // length of human readable data
     uint8_t          *data_bytes;  // the record's content
-    char            *data;      // human readable data 
+    char             *data;      // human readable data 
     struct DNSRecord *next;        // linked list next pointer
 } DNSRecord;
 
 typedef struct DNSPacket
 {
-    DNSHeader       *header;
-    DNSQuestion     *questions;
-    DNSRecord       *answers;
-    DNSRecord       *authorities;
-    DNSRecord       *additionals;
+    DNSHeader   *header;
+    DNSQuestion *questions;
+    DNSRecord   *answers;
+    DNSRecord   *authorities;
+    DNSRecord   *additionals;
 } DNSPacket;
 
 DNSHeader*   NewDNSHeader(uint16_t id, uint16_t flags, uint16_t num_questions);
@@ -64,21 +64,29 @@ DNSQuestion* NewDNSQuestion(char *encoded_name, uint16_t type, uint16_t class);
 DNSQuery*    NewDNSQuery(char *domain_name, uint16_t record_type);
 DNSPacket*   NewDNSPacket(const char *response_bytes);
 
+int          destroy_DNSPacket(DNSPacket** packet);
+int          destroy_DNSHeader(DNSHeader** header);
+int          destroy_DNSQuestion(DNSQuestion** question);
+int          destroy_DNSRecord(DNSRecord** record);
+
 void         display_DNSHeader(DNSHeader *header);
 void         display_DNSQuestion(DNSQuestion *question);
 void         display_DNSRecord(DNSRecord *record);
 void         display_DNSPacket(DNSPacket *packet);
 
-size_t        encode_dns_name(char* domain_name, char* res);
+size_t       encode_dns_name(char* domain_name, char* res);
 void         header_to_bytes(DNSHeader *header, char *header_bytes);
 void         question_to_bytes(DNSQuestion *question, char *question_bytes);
-size_t        parse_header(const char* response_bytes, DNSHeader *header);
-int          parse_question(const char* response_bytes, int bytes_in, DNSQuestion *question);
-int          parse_record(const char* response_bytes, int bytes_in, DNSRecord *record);
-int          parse_records(const char *response_bytes, int bytes_read, int num_records, DNSRecord **head);
+size_t       parse_header(const char* response_bytes, DNSHeader *header);
 int          parse_questions(const char *response_bytes, int bytes_read, int num_questions, DNSQuestion **head);
+int          parse_question(const char* response_bytes, int bytes_in, DNSQuestion *question);
+int          parse_records(const char *response_bytes, int bytes_read, int num_records, DNSRecord **head);
+int          parse_record(const char* response_bytes, int bytes_in, DNSRecord *record);
+
 int          decode_name(const char* response_bytes, int bytes_in, char *decoded_name);
 int          decode_compressed_name(const char* response_bytes, int bytes_in, char *decoded_name);
+
+
 
 DNSPacket * send_query(char *addr, char *domain, u_int16_t type);
 #endif // REQUEST_H

--- a/dns.h
+++ b/dns.h
@@ -31,8 +31,8 @@ typedef struct DNSQuestion
 {
     // stored in network byte order
     char               *name;
-    u_int16_t           type;       // set to TYPE_A=1 (A Record)
-    u_int16_t           class;      // set to CLASS_IN=1 (for internet)
+    uint16_t            type;       // set to TYPE_A=1 (A Record)
+    uint16_t            class;      // set to CLASS_IN=1 (for internet)
     struct DNSQuestion *next;       // linked list next pointer
 } DNSQuestion;
 
@@ -66,6 +66,7 @@ DNSPacket*   NewDNSPacket(const char *response_bytes);
 
 int          destroy_DNSPacket(DNSPacket** packet);
 int          destroy_DNSHeader(DNSHeader** header);
+int	     destroy_DNSQuery(DNSQuery** query);
 int          destroy_DNSQuestion(DNSQuestion** question);
 int          destroy_DNSRecord(DNSRecord** record);
 

--- a/main.c
+++ b/main.c
@@ -11,10 +11,9 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    DNSPacket *packet = send_query("198.41.0.4", argv[1], TYPE_A);
+    DNSPacket *packet = send_query("8.8.8.8", argv[1], TYPE_A);
     display_DNSPacket(packet);
-
-    // destroy_DNSPacket(packet);
+    destroy_DNSPacket(&packet);
 
     return 0;
 }


### PR DESCRIPTION
This PR adds destroy functions for all DNS structs:
- `destroy_DNSPacket()`
- `destroy_DNSHeader()`
- `destroy_DNSQuestion()`
- `destroy_DNSRecord()`

Each of these takes a double pointer to the struct in question so that the pointer to the struct being destroyed can be set to `NULL` in addition to all of it's `malloc`ed memory being freed.

My only question is whether I am correctly destroying the `*next` pointers for the `DNSRecord` and `DNSQuestion` structs. I believe I am, since the space `malloc`ed for each of these pointers will be destroyed on the next iteration of the loop, when `cur` is the memory where `*next` had previously pointed.

Could @pjg11 or @AveryBurke have a look before merging?